### PR TITLE
Using bitbucket workspace slug as the name

### DIFF
--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -119,7 +119,7 @@ type orgMemberPermission struct {
 
 func convertOrganization(from *organization) *scm.Organization {
 	return &scm.Organization{
-		Name:   from.Name,
+		Name:   from.Slug,
 		Avatar: fmt.Sprintf("https://bitbucket.org/workspaces/%s/avatar", from.Slug),
 	}
 }


### PR DESCRIPTION
it is necessary to use the slug to access the related APIs